### PR TITLE
using setuptools to enable bdist_wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@
 
 import sys as _sys
 from _setup import run
-
+from setuptools import setup
 
 def setup(args=None, _manifest=0):
     """ Main setup function """


### PR DESCRIPTION
I am trying to build a wheel package in windows. setuptools should be imported.
http://stackoverflow.com/questions/26664102/why-can-i-not-create-a-wheel-in-python
