### PR TITLE
Setup CI via Github actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,5 +15,8 @@ indent_style = tab
 [*.json]
 indent_size = 4
 
+[*.yml]
+indent_size = 2
+
 [*.md]
 trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,18 +12,24 @@ jobs:
         versions:
           - python: 2.7
             toxenv: py27
+            os: ubuntu-latest
           - python: 3.4
             toxenv: py34
+            os: ubuntu-18.04
           - python: 3.5
             toxenv: py35
+            os: ubuntu-latest
           - python: 3.6
             toxenv: py36
+            os: ubuntu-latest
           - python: 3.7
             toxenv: py37
+            os: ubuntu-latest
           - python: 3.7
             toxenv: cov-report
+            os: ubuntu-latest
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.versions.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,6 @@ jobs:
           - python: 3.7
             toxenv: py37
             os: ubuntu-latest
-          - python: 3.7
-            toxenv: cov-report
-            os: ubuntu-latest
 
     runs-on: ${{ matrix.versions.os }}
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        versions:
+          - python: 2.7
+            toxenv: py27
+          - python: 3.4
+            toxenv: py34
+          - python: 3.5
+            toxenv: py35
+          - python: 3.6
+            toxenv: py36
+          - python: 3.7
+            toxenv: py37
+          - python: 3.7
+            toxenv: cov-report
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.versions.python }}
+      - run: pip install -r development.txt
+      - run: invoke build
+      - run: invoke test -e ${{ matrix.versions.toxenv }}
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
           - python: 2.7
             toxenv: py27
             os: ubuntu-latest
-          - python: 3.4
-            toxenv: py34
-            os: ubuntu-18.04
           - python: 3.5
             toxenv: py35
             os: ubuntu-latest

--- a/debug.unix.cflags
+++ b/debug.unix.cflags
@@ -6,7 +6,7 @@
 -fprofile-arcs
 
 # don't compile on weird code
--std=c89 -pedantic -fno-strict-aliasing -Werror
+-std=c99 -pedantic -fno-strict-aliasing -Werror
 -Wall
 -Wbad-function-cast
 -Wcast-align


### PR DESCRIPTION
I've added a workflow file with the steps that -I think- are required to run the build and tests.

Due to Github actions limitation/restriction, a new workflow added on a fork isn't run on pull request (for security reasons I guess), so the status doesn't show up here, but you can see the results in the actions tab on my fork: https://github.com/browniebroke/rcssmin/actions